### PR TITLE
Fix retrieved data of readers for PHP 8.1

### DIFF
--- a/src/Profile/Magento/Gateway/Connection/ConnectionFactory.php
+++ b/src/Profile/Magento/Gateway/Connection/ConnectionFactory.php
@@ -36,6 +36,9 @@ class ConnectionFactory implements ConnectionFactoryInterface
             'port' => $credentials['dbPort'] ?? '',
             'driver' => 'pdo_mysql',
             'charset' => 'utf8mb4',
+            'driverOptions' => [
+                \PDO::ATTR_STRINGIFY_FETCHES => true,
+            ],
         ];
 
         $connection = DriverManager::getConnection($connectionParams);


### PR DESCRIPTION
Since PHP 8.1 the option \PDO::ATTR_STRINGIFY_FETCHES defaults to false, which causes many TypeErrors in migrations.