### PR TITLE
New PHP/DB versions

### DIFF
--- a/src/Profile/Magento/Gateway/Connection/ConnectionFactory.php
+++ b/src/Profile/Magento/Gateway/Connection/ConnectionFactory.php
@@ -36,6 +36,9 @@ class ConnectionFactory implements ConnectionFactoryInterface
             'port' => $credentials['dbPort'] ?? '',
             'driver' => 'pdo_mysql',
             'charset' => 'utf8mb4',
+            'driverOptions' => [
+                \PDO::ATTR_STRINGIFY_FETCHES => true,
+            ],
         ];
 
         $connection = DriverManager::getConnection($connectionParams);


### PR DESCRIPTION
Since PHP 8.1, the data for a SELECT is no longer returned as PHP strings by default, but now has correct data types such as integer or float.

https://stackoverflow.com/questions/73169064/swag-migration-run-exception-in-logs-while-migrating-from-shopware5-to-shopware6

@mitelg Thanks!