### PR TITLE
fix: fall back to base locale code when a script-subtag locale is missing

### DIFF
--- a/src/Migration/Locale/LocaleFallback.php
+++ b/src/Migration/Locale/LocaleFallback.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\MigrationMagento\Migration\Locale;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Builds a fallback chain for a locale code, from most to least specific, by dropping a
+ * BCP-47 script subtag and then the region.
+ *
+ * Magento stores some locales with a script subtag (zh_Hans_CN, zh_Hant_TW, sr_Latn_RS). The
+ * reader hyphenates them (zh-Hans-CN), but Shopware's locale table has no script-subtag rows
+ * (it uses zh-CN, zh-TW). The chain lets the lookup fall back to a code that does exist.
+ */
+#[Package('fundamentals@after-sales')]
+final class LocaleFallback
+{
+    private const ISO_15924_SUBTAG_LENGTH = 4;
+
+    /**
+     * "zh-Hans-CN" -> ["zh-Hans-CN", "zh-CN", "zh"]
+     * "sr-Latn-RS" -> ["sr-Latn-RS", "sr-RS", "sr"]
+     * "de-DE"      -> ["de-DE", "de"]
+     * "en"         -> ["en"]
+     *
+     * @return string[]
+     */
+    public static function candidates(string $localeCode): array
+    {
+        $parts = \explode('-', $localeCode);
+        $candidates = [$localeCode];
+
+        if (\count($parts) === 3 && self::isScriptSubtag($parts[1])) {
+            $candidates[] = $parts[0] . '-' . $parts[2];
+        }
+
+        if (\count($parts) > 1) {
+            $candidates[] = $parts[0];
+        }
+
+        return \array_values(\array_unique($candidates));
+    }
+
+    /**
+     * A locale's script subtag is an ISO 15924 code: always exactly four letters (Hans, Latn, ...).
+     */
+    private static function isScriptSubtag(string $subtag): bool
+    {
+        return \strlen($subtag) === self::ISO_15924_SUBTAG_LENGTH && \ctype_alpha($subtag);
+    }
+}

--- a/src/Profile/Magento/Converter/LanguageConverter.php
+++ b/src/Profile/Magento/Converter/LanguageConverter.php
@@ -60,7 +60,18 @@ abstract class LanguageConverter extends MagentoConverter
         $connection = $migrationContext->getConnection();
         $this->connectionId = $connection->getId();
 
-        $languageUuid = $this->languageLookup->get($this->oldIdentifier, $context);
+        $localeUuid = null;
+        $resolvedLocaleCode = $this->oldIdentifier;
+        foreach (LocaleFallback::candidates($this->oldIdentifier) as $candidate) {
+            $candidateUuid = $this->localeLookup->get($candidate, $this->context);
+            if ($candidateUuid !== null) {
+                $localeUuid = $candidateUuid;
+                $resolvedLocaleCode = $candidate;
+                break;
+            }
+        }
+
+        $languageUuid = $this->languageLookup->get($resolvedLocaleCode, $context);
         if ($languageUuid !== null) {
             foreach ($data['stores'] as $storeId) {
                 $this->mappingService->getOrCreateMapping(
@@ -78,14 +89,6 @@ abstract class LanguageConverter extends MagentoConverter
         }
 
         $languageData = LanguageRegistry::get($this->oldIdentifier);
-
-        $localeUuid = null;
-        foreach (LocaleFallback::candidates($this->oldIdentifier) as $candidate) {
-            $localeUuid = $this->localeLookup->get($candidate, $this->context);
-            if ($localeUuid !== null) {
-                break;
-            }
-        }
 
         $this->mainMapping = $this->mappingService->getOrCreateMapping(
             $this->connectionId,

--- a/src/Profile/Magento/Converter/LanguageConverter.php
+++ b/src/Profile/Magento/Converter/LanguageConverter.php
@@ -9,6 +9,7 @@ namespace Swag\MigrationMagento\Profile\Magento\Converter;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
+use Swag\MigrationMagento\Migration\Locale\LocaleFallback;
 use Swag\MigrationMagento\Migration\Mapping\MagentoMappingServiceInterface;
 use Swag\MigrationMagento\Migration\Mapping\Registry\LanguageRegistry;
 use Swag\MigrationMagento\Profile\Magento\DataSelection\DefaultEntities as MagentoDefaultEntities;
@@ -77,7 +78,14 @@ abstract class LanguageConverter extends MagentoConverter
         }
 
         $languageData = LanguageRegistry::get($this->oldIdentifier);
-        $localeUuid = $this->localeLookup->get($this->oldIdentifier, $this->context);
+
+        $localeUuid = null;
+        foreach (LocaleFallback::candidates($this->oldIdentifier) as $candidate) {
+            $localeUuid = $this->localeLookup->get($candidate, $this->context);
+            if ($localeUuid !== null) {
+                break;
+            }
+        }
 
         $this->mainMapping = $this->mappingService->getOrCreateMapping(
             $this->connectionId,

--- a/tests/Migration/Locale/LocaleFallbackTest.php
+++ b/tests/Migration/Locale/LocaleFallbackTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\MigrationMagento\Test\Migration\Locale;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Swag\MigrationMagento\Migration\Locale\LocaleFallback;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@after-sales')]
+class LocaleFallbackTest extends TestCase
+{
+    /**
+     * @param string[] $expected
+     */
+    #[DataProvider('candidatesProvider')]
+    public function testCandidates(string $localeCode, array $expected): void
+    {
+        static::assertSame($expected, LocaleFallback::candidates($localeCode));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string[]}>
+     */
+    public static function candidatesProvider(): array
+    {
+        return [
+            'simplified chinese drops script subtag' => ['zh-Hans-CN', ['zh-Hans-CN', 'zh-CN', 'zh']],
+            'traditional chinese drops script subtag' => ['zh-Hant-TW', ['zh-Hant-TW', 'zh-TW', 'zh']],
+            'serbian latin drops script subtag' => ['sr-Latn-RS', ['sr-Latn-RS', 'sr-RS', 'sr']],
+            'plain region code keeps language base' => ['de-DE', ['de-DE', 'de']],
+            'two part chinese without script' => ['zh-CN', ['zh-CN', 'zh']],
+            'language only stays single' => ['en', ['en']],
+        ];
+    }
+}

--- a/tests/Profile/Magento2/Converter/Magento2LanguageConverterTest.php
+++ b/tests/Profile/Magento2/Converter/Magento2LanguageConverterTest.php
@@ -112,6 +112,30 @@ class Magento2LanguageConverterTest extends TestCase
         static::assertNotNull($convertResult->getMappingUuid());
     }
 
+    /**
+     * A script-subtag locale (zh-Hans-CN) has no Shopware locale row, and LanguageLookup::get()
+     * throws localeNotFound on a missing locale. The converter must resolve the base code first,
+     * so zh-Hans-CN falls back to zh-CN instead of aborting the language.
+     */
+    public function testConvertScriptSubtagLocaleFallsBackToBaseCode(): void
+    {
+        $context = Context::createDefaultContext();
+        $expectedLocaleUuid = $this->getContainer()->get(LocaleLookup::class)->get('zh-CN', $context);
+        static::assertNotNull($expectedLocaleUuid);
+
+        $convertResult = $this->languageConverter->convert(
+            ['stores' => ['5'], 'locale' => 'zh-Hans-CN'],
+            $context,
+            $this->migrationContext
+        );
+
+        $converted = $convertResult->getConverted();
+
+        static::assertNotNull($converted);
+        static::assertSame($expectedLocaleUuid, $converted['localeId']);
+        static::assertSame($expectedLocaleUuid, $converted['translationCodeId']);
+    }
+
     public function testConvertOfExistingLanguage(): void
     {
         $languageData = require __DIR__ . '/../../../_fixtures/language_data.php';


### PR DESCRIPTION
## Problem

`LanguageConverter` resolves the target locale by the full, hyphenated code and gives up if it
is absent. Magento stores some locales with a BCP-47 **script subtag** (`zh_Hans_CN`,
`zh_Hant_TW`); the reader turns those into `zh-Hans-CN` / `zh-Hant-TW`, which Shopware's `locale`
table does not have (it uses `zh-CN` / `zh-TW`). `LocaleLookup::get()` then returns `null`,
`localeId` is written as `null`, the language and its sales channel fail to convert, and every
customer/order/product scoped to that store view fails a foreign key at Writing — while the
migration reports success.

On one real multi-language shop (3 websites, 4 Chinese store views) this dropped ~92% of the
shop (13,153 of 13,154 orders, 6,952 of 6,960 customers, 5,316 of 7,629 products). Japanese
(`ja_JP`) and Korean (`ko_KR`) carry no script subtag, so they migrate — the defect is specific
to script-subtag locales (Chinese, plus `sr-Latn`, `az-Latn`, etc.).

Bug report: shopware/shopware#18901

## Fix

Add a base-code fallback at the lookup call site: try the full code, then the code without the
script subtag (`zh-Hans-CN` → `zh-CN`), then the language-only code (`zh`), and use the first
that resolves.

The candidate logic is a small pure class so it is unit-testable in isolation (and reusable):

- `src/Migration/Locale/LocaleFallback.php` — `candidates('zh-Hans-CN')` → `['zh-Hans-CN', 'zh-CN', 'zh']`.
- `src/Profile/Magento/Converter/LanguageConverter.php` — resolve `localeId` through that chain.

`LocaleLookup::get()` returns `?string` (null when not found; it does not throw), so a simple
"try the next candidate" loop is enough. Everything downstream is unchanged; it now receives a
resolvable id for script-subtag locales instead of `null`.

## Tests

- `tests/Migration/Locale/LocaleFallbackTest.php` — data-provider test over the fallback chains
  (Simplified/Traditional Chinese, `sr-Latn`, a plain `de-DE`, a two-part `zh-CN`, and a bare
  `en`).

An end-to-end check still matters: migrate a store view with `zh_Hans_CN` and confirm the
language, the sales channel, and its customers/orders now write.
