### PR TITLE
fix: terminate failed Magento media downloads

### DIFF
--- a/src/Profile/Magento/Media/LocalMediaProcessor.php
+++ b/src/Profile/Magento/Media/LocalMediaProcessor.php
@@ -10,6 +10,7 @@ namespace Swag\MigrationMagento\Profile\Magento\Media;
 use Doctrine\DBAL\Connection;
 use GuzzleHttp\Client;
 use GuzzleHttp\Promise;
+use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\Utils;
 use GuzzleHttp\Psr7\Response;
 use Shopware\Core\Content\Media\File\FileSaver;
@@ -101,7 +102,14 @@ abstract class LocalMediaProcessor extends BaseMediaService implements MediaFile
                         ->build(MediaFileMissingLog::class)
                 );
 
-                return $workload;
+                $failureUuids = \array_keys($mappedWorkload);
+                foreach ($mappedWorkload as $mappedWork) {
+                    $mappedWork->setState(MediaProcessWorkloadStruct::ERROR_STATE);
+                }
+
+                $this->setProcessedFlag($migrationContext->getRunUuid(), $context, [], $failureUuids);
+
+                return \array_values($mappedWorkload);
             }
 
             return $this->downloadMediaFiles(
@@ -162,8 +170,7 @@ abstract class LocalMediaProcessor extends BaseMediaService implements MediaFile
             $workload->setCurrentOffset((int) $additionalData['file_size']);
             $workload->setState(MediaProcessWorkloadStruct::FINISH_STATE);
         } catch (\Exception $exception) {
-            $promise = null;
-            $workload->setErrorCount($workload->getErrorCount() + 1);
+            $promise = Create::rejectionFor($exception);
         }
 
         return $promise;
@@ -411,7 +418,7 @@ abstract class LocalMediaProcessor extends BaseMediaService implements MediaFile
         Context $context,
     ): array {
         // Do download requests and store the promises
-        $client = new Client();
+        $client = new Client(['timeout' => $this->migrationConfig->migrationRequestTimeout]);
         $promises = $this->doMediaDownloadRequests($media, $mappedWorkload, $client, $shopUrl);
 
         // Wait for the requests to complete, even if some of them fail

--- a/src/Profile/Magento/Media/LocalMediaProcessor.php
+++ b/src/Profile/Magento/Media/LocalMediaProcessor.php
@@ -156,7 +156,7 @@ abstract class LocalMediaProcessor extends BaseMediaService implements MediaFile
         return $promises;
     }
 
-    #[ReturnTypeNarrowing(version: '14.0.0', newType: Promise\PromiseInterface::class)]
+    #[ReturnTypeNarrowing(version: 'v14.0.0', newType: Promise\PromiseInterface::class)]
     protected function doNormalDownloadRequest(MediaProcessWorkloadStruct $workload, Client $client): ?Promise\PromiseInterface
     {
         $additionalData = $workload->getAdditionalData();

--- a/src/Profile/Magento/Media/LocalMediaProcessor.php
+++ b/src/Profile/Magento/Media/LocalMediaProcessor.php
@@ -20,6 +20,7 @@ use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Deprecation\BCChange\ReturnTypeNarrowing;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Swag\MigrationMagento\Exception\MigrationMagentoException;
@@ -155,6 +156,7 @@ abstract class LocalMediaProcessor extends BaseMediaService implements MediaFile
         return $promises;
     }
 
+    #[ReturnTypeNarrowing(version: '14.0.0', newType: Promise\PromiseInterface::class)]
     protected function doNormalDownloadRequest(MediaProcessWorkloadStruct $workload, Client $client): ?Promise\PromiseInterface
     {
         $additionalData = $workload->getAdditionalData();

--- a/tests/Profile/Magento/Media/LocalMediaProcessorTest.php
+++ b/tests/Profile/Magento/Media/LocalMediaProcessorTest.php
@@ -58,7 +58,7 @@ class LocalMediaProcessorTest extends TestCase
                 $media['media_id'],
                 $runId,
                 MediaProcessWorkloadStruct::IN_PROGRESS_STATE,
-                ['path' => $media['path'], 'fileSize' => $media['file_size'], 'fileName' => $media['file_name']]
+                ['path' => $media['uri'], 'fileSize' => $media['file_size'], 'fileName' => $media['file_name']]
             );
         }
         unset($media);

--- a/tests/Profile/Magento/Media/LocalMediaProcessorTest.php
+++ b/tests/Profile/Magento/Media/LocalMediaProcessorTest.php
@@ -78,7 +78,7 @@ class LocalMediaProcessorTest extends TestCase
 
         Context::createDefaultContext();
 
-        $mediaProcessor = $this->createLocaleMediaProcessor($mediaFiles);
+        $mediaProcessor = $this->createLocaleMediaProcessor($mediaFiles, 2);
         $reflectionMethod = (new \ReflectionClass(LocalMediaProcessor::class))->getMethod('copyMediaFiles');
 
         $result = $reflectionMethod->invokeArgs(

--- a/tests/Profile/Magento/Media/LocalMediaProcessorTest.php
+++ b/tests/Profile/Magento/Media/LocalMediaProcessorTest.php
@@ -8,6 +8,8 @@
 namespace Swag\MigrationMagento\Test\Profile\Magento\Media;
 
 use Doctrine\DBAL\Connection;
+use GuzzleHttp\Client;
+use GuzzleHttp\Promise;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\File\FileSaver;
 use Shopware\Core\Content\Media\File\MediaFile;
@@ -18,7 +20,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
-use Swag\MigrationMagento\Profile\Magento\Media\LocalMediaProcessor;
 use Swag\MigrationMagento\Profile\Magento24\Magento24Profile;
 use SwagMigrationAssistant\Migration\Connection\SwagMigrationConnectionEntity;
 use SwagMigrationAssistant\Migration\Logging\LoggingServiceInterface;
@@ -27,7 +28,6 @@ use SwagMigrationAssistant\Migration\Media\SwagMigrationMediaFileCollection;
 use SwagMigrationAssistant\Migration\Media\SwagMigrationMediaFileDefinition;
 use SwagMigrationAssistant\Migration\MigrationConfiguration;
 use SwagMigrationAssistant\Migration\MigrationContext;
-use SwagMigrationAssistant\Migration\MigrationContextInterface;
 
 /**
  * @internal
@@ -35,17 +35,24 @@ use SwagMigrationAssistant\Migration\MigrationContextInterface;
 #[Package('fundamentals@after-sales')]
 class LocalMediaProcessorTest extends TestCase
 {
+    /**
+     * @var StaticEntityRepository<SwagMigrationMediaFileCollection>
+     */
+    private StaticEntityRepository $migrationMediaFileRepo;
+
     public function testCopyMediaFiles(): void
     {
         $runId = Uuid::randomHex();
+        $fixtureDirectory = __DIR__ . '/_fixtures';
 
         $mediaFiles = [
-            $this->createFileData(__DIR__ . '/_fixtures/test1.jpg', $runId),
-            $this->createFileData(__DIR__ . '/_fixtures/test2.jpg', $runId),
+            $this->createFileData($fixtureDirectory . '/test1.jpg', $runId),
+            $this->createFileData($fixtureDirectory . '/test2.jpg', $runId),
         ];
 
         $mappedWorkload = [];
-        foreach ($mediaFiles as $media) {
+        foreach ($mediaFiles as &$media) {
+            $media['uri'] = '/' . $media['file_name'];
             $mappedWorkload[$media['media_id']] = new MediaProcessWorkloadStruct(
                 $media['media_id'],
                 $runId,
@@ -53,9 +60,13 @@ class LocalMediaProcessorTest extends TestCase
                 ['path' => $media['path'], 'fileSize' => $media['file_size'], 'fileName' => $media['file_name']]
             );
         }
+        unset($media);
+
+        $connection = new SwagMigrationConnectionEntity();
+        $connection->setCredentialFields(['installationRoot' => $fixtureDirectory]);
 
         $migrationContext = new MigrationContext(
-            new SwagMigrationConnectionEntity(),
+            $connection,
             new Magento24Profile(),
             null,
             null,
@@ -64,12 +75,8 @@ class LocalMediaProcessorTest extends TestCase
             100
         );
 
-        Context::createDefaultContext();
-
-        $mediaProcessor = $this->createLocaleMediaProcessor($mediaFiles);
-        $reflectionMethod = (new \ReflectionClass(LocalMediaProcessor::class))->getMethod('copyMediaFiles');
-        $reflectionMethod->setAccessible(true);
-        $result = $reflectionMethod->invokeArgs($mediaProcessor, [$mediaFiles, $mappedWorkload, $migrationContext, Context::createDefaultContext()]);
+        $mediaProcessor = $this->createLocaleMediaProcessor($mediaFiles, 2);
+        $result = $mediaProcessor->process($migrationContext, Context::createDefaultContext(), \array_values($mappedWorkload));
 
         foreach ($result as $workload) {
             static::assertInstanceOf(MediaProcessWorkloadStruct::class, $workload);
@@ -77,34 +84,119 @@ class LocalMediaProcessorTest extends TestCase
         }
     }
 
+    public function testMissingShopUrlMarksMediaAsFailed(): void
+    {
+        $runId = Uuid::randomHex();
+        $mediaFile = $this->createFileData(__DIR__ . '/_fixtures/test1.jpg', $runId);
+        $connection = new SwagMigrationConnectionEntity();
+        $connection->setCredentialFields(['installationRoot' => '/path/does/not/exist']);
+        $migrationContext = $this->createMigrationContext($connection, $runId);
+        $workload = new MediaProcessWorkloadStruct($mediaFile['media_id'], $runId);
+
+        $result = $this->createLocaleMediaProcessor([$mediaFile])->process(
+            $migrationContext,
+            Context::createDefaultContext(),
+            [$workload]
+        );
+
+        static::assertSame(MediaProcessWorkloadStruct::ERROR_STATE, $result[0]->getState());
+        static::assertSame(
+            [[['id' => $mediaFile['id'], 'processFailure' => true]]],
+            $this->migrationMediaFileRepo->updates
+        );
+    }
+
+    public function testRejectedDownloadMarksMediaAsFailedAfterThreshold(): void
+    {
+        $runId = Uuid::randomHex();
+        $mediaFile = $this->createFileData(__DIR__ . '/_fixtures/test1.jpg', $runId);
+        $connection = new SwagMigrationConnectionEntity();
+        $connection->setCredentialFields([
+            'installationRoot' => '/path/does/not/exist',
+            'shopUrl' => 'https://unreachable.invalid',
+        ]);
+        $migrationContext = $this->createMigrationContext($connection, $runId);
+        $workload = new MediaProcessWorkloadStruct(
+            $mediaFile['media_id'],
+            $runId,
+            errorCount: 3
+        );
+        $processor = $this->createLocaleMediaProcessor([$mediaFile]);
+        $processor->rejectDownloads = true;
+
+        $result = $processor->process($migrationContext, Context::createDefaultContext(), [$workload]);
+
+        static::assertSame(MediaProcessWorkloadStruct::ERROR_STATE, $result[0]->getState());
+        static::assertSame(
+            [[['id' => $mediaFile['id'], 'processFailure' => true]]],
+            $this->migrationMediaFileRepo->updates
+        );
+    }
+
+    public function testSynchronousRequestExceptionCreatesRejectedPromise(): void
+    {
+        $client = new Client([
+            'handler' => static function (): never {
+                throw new \RuntimeException('unreachable');
+            },
+        ]);
+        $workload = new MediaProcessWorkloadStruct(
+            Uuid::randomHex(),
+            Uuid::randomHex(),
+            additionalData: ['uri' => 'https://unreachable.invalid/media.jpg', 'file_size' => 10]
+        );
+        $processor = $this->createLocaleMediaProcessor([]);
+
+        $result = Promise\Utils::settle([$processor->request($workload, $client)])->wait();
+
+        static::assertSame('rejected', $result[0]['state']);
+        static::assertSame(0, $workload->getErrorCount());
+    }
+
     /**
      * @param array<int, mixed> $mediaFiles
      */
-    private function createLocaleMediaProcessor(array $mediaFiles): LocalMediaProcessor
+    private function createLocaleMediaProcessor(array $mediaFiles, int $expectedPersistedFiles = 0): TestLocalMediaProcessor
     {
-        /** @var StaticEntityRepository<SwagMigrationMediaFileCollection> $migrationMediaFileRepo */
-        $migrationMediaFileRepo = new StaticEntityRepository(
-            [],
-            new SwagMigrationMediaFileDefinition()
+        $this->migrationMediaFileRepo = StaticEntityRepository::of(
+            SwagMigrationMediaFileCollection::class,
+            definition: new SwagMigrationMediaFileDefinition()
         );
 
-        /** @var StaticEntityRepository<MediaCollection> $mediaFileRepo */
-        $mediaFileRepo = new StaticEntityRepository(
-            [],
-            new MediaDefinition(),
+        $mediaFileRepo = StaticEntityRepository::of(
+            MediaCollection::class,
+            definition: new MediaDefinition(),
         );
 
         $loggerMock = $this->createMock(LoggingServiceInterface::class);
 
+        $requestedMediaIds = [];
+        $databaseMediaFiles = $this->mediaIdsFromHexToBytes($mediaFiles);
         $queryBuilderMock = $this->createMock(QueryBuilder::class);
-        $queryBuilderMock->method('fetchAllAssociative')->willReturn($this->mediaIdsFromHexToBytes($mediaFiles));
+        $queryBuilderMock->method('setParameter')->willReturnCallback(
+            static function (string $key, mixed $value) use (&$requestedMediaIds, $queryBuilderMock): QueryBuilder {
+                if ($key === 'ids') {
+                    $requestedMediaIds = $value;
+                }
+
+                return $queryBuilderMock;
+            }
+        );
+        $queryBuilderMock->method('fetchAllAssociative')->willReturnCallback(
+            static function () use ($databaseMediaFiles, &$requestedMediaIds): array {
+                return \array_values(\array_filter(
+                    $databaseMediaFiles,
+                    static fn (array $mediaFile): bool => \in_array($mediaFile['media_id'], $requestedMediaIds, true)
+                ));
+            }
+        );
 
         $dbalConnectionMock = $this->createMock(Connection::class);
         $dbalConnectionMock->method('createQueryBuilder')->willReturn($queryBuilderMock);
 
         $fileSaverMock = $this->createMock(FileSaver::class);
         // TestCase: Check that the filename starts with "/tmp/", the file exists and the size is correct
-        $fileSaverMock->expects($this->exactly(2))
+        $fileSaverMock->expects($this->exactly($expectedPersistedFiles))
             ->method('persistFileToMedia')
             ->willReturnCallback(static function ($mediaFile, $destination, $mediaId): void {
                 static::assertInstanceOf(MediaFile::class, $mediaFile);
@@ -120,12 +212,29 @@ class LocalMediaProcessorTest extends TestCase
                 static::assertTrue(Uuid::isValid($mediaId));
             });
 
-        return new class($migrationMediaFileRepo, $mediaFileRepo, $fileSaverMock, $loggerMock, $dbalConnectionMock, new MigrationConfiguration()) extends LocalMediaProcessor {
-            public function supports(MigrationContextInterface $migrationContext): bool
-            {
-                return true;
-            }
-        };
+        return new TestLocalMediaProcessor(
+            $this->migrationMediaFileRepo,
+            $mediaFileRepo,
+            $fileSaverMock,
+            $loggerMock,
+            $dbalConnectionMock,
+            new MigrationConfiguration()
+        );
+    }
+
+    private function createMigrationContext(
+        SwagMigrationConnectionEntity $connection,
+        string $runId,
+    ): MigrationContext {
+        return new MigrationContext(
+            $connection,
+            new Magento24Profile(),
+            null,
+            null,
+            $runId,
+            0,
+            100
+        );
     }
 
     /**

--- a/tests/Profile/Magento/Media/LocalMediaProcessorTest.php
+++ b/tests/Profile/Magento/Media/LocalMediaProcessorTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Swag\MigrationMagento\Profile\Magento\Media\LocalMediaProcessor;
 use Swag\MigrationMagento\Profile\Magento24\Magento24Profile;
 use SwagMigrationAssistant\Migration\Connection\SwagMigrationConnectionEntity;
 use SwagMigrationAssistant\Migration\Logging\LoggingServiceInterface;

--- a/tests/Profile/Magento/Media/TestLocalMediaProcessor.php
+++ b/tests/Profile/Magento/Media/TestLocalMediaProcessor.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\MigrationMagento\Test\Profile\Magento\Media;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Promise;
+use GuzzleHttp\Promise\PromiseInterface;
+use Swag\MigrationMagento\Profile\Magento\Media\LocalMediaProcessor;
+use SwagMigrationAssistant\Migration\Media\MediaProcessWorkloadStruct;
+use SwagMigrationAssistant\Migration\MigrationContextInterface;
+
+/**
+ * @internal
+ */
+class TestLocalMediaProcessor extends LocalMediaProcessor
+{
+    public bool $rejectDownloads = false;
+
+    public function supports(MigrationContextInterface $migrationContext): bool
+    {
+        return true;
+    }
+
+    public function request(MediaProcessWorkloadStruct $workload, Client $client): PromiseInterface
+    {
+        $promise = $this->doNormalDownloadRequest($workload, $client);
+        if ($promise === null) {
+            throw new \RuntimeException('Expected a download promise.');
+        }
+
+        return $promise;
+    }
+
+    protected function doMediaDownloadRequests(array $media, array &$mappedWorkload, Client $client, string $shopUrl): array
+    {
+        if (!$this->rejectDownloads) {
+            return parent::doMediaDownloadRequests($media, $mappedWorkload, $client, $shopUrl);
+        }
+
+        $promises = [];
+        foreach ($media as $mediaFile) {
+            $uuid = \mb_strtolower($mediaFile['media_id']);
+            $mappedWorkload[$uuid]->setAdditionalData([
+                'uri' => $shopUrl . $mediaFile['uri'],
+                'file_size' => $mediaFile['file_size'],
+                'file_name' => $mediaFile['file_name'],
+            ]);
+            $promises[$uuid] = Promise\Create::rejectionFor(new \RuntimeException('unreachable'));
+        }
+
+        return $promises;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

When media files cannot be fetched from a Magento installation, failed downloads remain unprocessed and are retried indefinitely. This can cause the migration progress to exceed 100% and prevents the migration from reaching the Done state.

### 2. What does this change do, exactly?

The Magento media processor now marks media files as failed after the configured error threshold is reached.

This prevents unreachable media files from being re-enqueued indefinitely and allows the migration to continue and finish even if individual images cannot be downloaded.
