### PR TITLE
 fix: normalize Magento category media paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [NEXT]
+- Fixes errors when downloading media.
+- Fixes errors when migrating category images.
+
 # 13.0.0
 
 - Compatibility with Migration Assistant version 18.

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,7 @@
+# [NEXT]
+- Behebt Fehler beim Herunterladen von Medien.
+- Behebt Fehler bei der Migration von Kategoriebildern.
+
 # 13.0.0
 
 - Kompatibilität mit Migration Assistant Version 18.

--- a/src/Profile/Magento/Converter/CategoryConverter.php
+++ b/src/Profile/Magento/Converter/CategoryConverter.php
@@ -28,11 +28,9 @@ use SwagMigrationAssistant\Migration\MigrationContextInterface;
 #[Package('fundamentals@after-sales')]
 abstract class CategoryConverter extends MagentoConverter
 {
-    private const DIRECTORY_SEPERATOR = '/';
+    private const DIRECTORY_SEPARATOR = '/';
 
-    private const CATEGORY_MEDIA_PATH = '/media/catalog/category/';
-
-    private const CATEGORY_MEDIA_PATH_WITHOUT_SLASH = 'media/catalog/category/';
+    private const CATEGORY_MEDIA_PATH = 'media/catalog/category/';
 
     protected string $connectionId;
 
@@ -415,12 +413,12 @@ abstract class CategoryConverter extends MagentoConverter
 
     private function createMediaUri(string $path): string
     {
-        $normalizedPath = \ltrim($path, self::DIRECTORY_SEPERATOR);
+        $normalizedPath = \ltrim($path, self::DIRECTORY_SEPARATOR);
 
-        if (\str_starts_with($normalizedPath, self::CATEGORY_MEDIA_PATH_WITHOUT_SLASH)) {
-            return self::DIRECTORY_SEPERATOR . $normalizedPath;
+        if (\str_starts_with($normalizedPath, self::CATEGORY_MEDIA_PATH)) {
+            return self::DIRECTORY_SEPARATOR . $normalizedPath;
         }
 
-        return self::CATEGORY_MEDIA_PATH . $normalizedPath;
+        return self::DIRECTORY_SEPARATOR . self::CATEGORY_MEDIA_PATH . $normalizedPath;
     }
 }

--- a/src/Profile/Magento/Converter/CategoryConverter.php
+++ b/src/Profile/Magento/Converter/CategoryConverter.php
@@ -28,6 +28,12 @@ use SwagMigrationAssistant\Migration\MigrationContextInterface;
 #[Package('fundamentals@after-sales')]
 abstract class CategoryConverter extends MagentoConverter
 {
+    private const DIRECTORY_SEPERATOR = '/';
+
+    private const CATEGORY_MEDIA_PATH = '/media/catalog/category/';
+
+    private const CATEGORY_MEDIA_PATH_WITHOUT_SLASH = 'media/catalog/category/';
+
     protected string $connectionId;
 
     protected Context $context;
@@ -384,7 +390,7 @@ abstract class CategoryConverter extends MagentoConverter
             [
                 'runId' => $this->runId,
                 'entity' => MediaDataSet::getEntity(),
-                'uri' => '/media/catalog/category/' . $path,
+                'uri' => $this->createMediaUri($path),
                 'fileName' => $categoryMedia['id'],
                 'fileSize' => 0,
                 'mediaId' => $categoryMedia['id'],
@@ -405,5 +411,16 @@ abstract class CategoryConverter extends MagentoConverter
         }
 
         return true;
+    }
+
+    private function createMediaUri(string $path): string
+    {
+        $normalizedPath = \ltrim($path, self::DIRECTORY_SEPERATOR);
+
+        if (\str_starts_with($normalizedPath, self::CATEGORY_MEDIA_PATH_WITHOUT_SLASH)) {
+            return self::DIRECTORY_SEPERATOR . $normalizedPath;
+        }
+
+        return self::CATEGORY_MEDIA_PATH . $normalizedPath;
     }
 }

--- a/tests/Profile/Magento/Media/LocalMediaProcessorTest.php
+++ b/tests/Profile/Magento/Media/LocalMediaProcessorTest.php
@@ -68,7 +68,6 @@ class LocalMediaProcessorTest extends TestCase
 
         $mediaProcessor = $this->createLocaleMediaProcessor($mediaFiles);
         $reflectionMethod = (new \ReflectionClass(LocalMediaProcessor::class))->getMethod('copyMediaFiles');
-        $reflectionMethod->setAccessible(true);
         $result = $reflectionMethod->invokeArgs($mediaProcessor, [$mediaFiles, $mappedWorkload, $migrationContext, Context::createDefaultContext()]);
 
         foreach ($result as $workload) {

--- a/tests/Profile/Magento2/Converter/Magento2CategoryConverterTest.php
+++ b/tests/Profile/Magento2/Converter/Magento2CategoryConverterTest.php
@@ -7,6 +7,7 @@
 
 namespace Swag\MigrationMagento\Test\Profile\Magento2\Converter;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -76,9 +77,11 @@ class Magento2CategoryConverterTest extends TestCase
 
     private string $defaultLanguageUuid;
 
+    private DummyMediaFileService $mediaFileService;
+
     protected function setUp(): void
     {
-        $mediaFileService = new DummyMediaFileService();
+        $this->mediaFileService = new DummyMediaFileService();
         $mappingService = new DummyMagentoMappingService();
         $this->loggingService = new DummyLoggingService();
 
@@ -163,10 +166,10 @@ class Magento2CategoryConverterTest extends TestCase
         $defaultCmsPageLookup = $this->getContainer()->get(DefaultCmsPageLookup::class);
         $languageLookup = $this->getContainer()->get(LanguageLookup::class);
 
-        $this->categoryConverter20 = new Magento20CategoryConverter($mappingService, $this->loggingService, $mediaFileService, $mediaFolderLookup, $lowestRootCategoryLookup, $defaultCmsPageLookup, $languageLookup);
-        $this->categoryConverter21 = new Magento21CategoryConverter($mappingService, $this->loggingService, $mediaFileService, $mediaFolderLookup, $lowestRootCategoryLookup, $defaultCmsPageLookup, $languageLookup);
-        $this->categoryConverter22 = new Magento22CategoryConverter($mappingService, $this->loggingService, $mediaFileService, $mediaFolderLookup, $lowestRootCategoryLookup, $defaultCmsPageLookup, $languageLookup);
-        $this->categoryConverter23 = new Magento23CategoryConverter($mappingService, $this->loggingService, $mediaFileService, $mediaFolderLookup, $lowestRootCategoryLookup, $defaultCmsPageLookup, $languageLookup);
+        $this->categoryConverter20 = new Magento20CategoryConverter($mappingService, $this->loggingService, $this->mediaFileService, $mediaFolderLookup, $lowestRootCategoryLookup, $defaultCmsPageLookup, $languageLookup);
+        $this->categoryConverter21 = new Magento21CategoryConverter($mappingService, $this->loggingService, $this->mediaFileService, $mediaFolderLookup, $lowestRootCategoryLookup, $defaultCmsPageLookup, $languageLookup);
+        $this->categoryConverter22 = new Magento22CategoryConverter($mappingService, $this->loggingService, $this->mediaFileService, $mediaFolderLookup, $lowestRootCategoryLookup, $defaultCmsPageLookup, $languageLookup);
+        $this->categoryConverter23 = new Magento23CategoryConverter($mappingService, $this->loggingService, $this->mediaFileService, $mediaFolderLookup, $lowestRootCategoryLookup, $defaultCmsPageLookup, $languageLookup);
     }
 
     public function testSupports(): void
@@ -222,6 +225,46 @@ class Magento2CategoryConverterTest extends TestCase
             \mb_substr($categoryData[1]['translations']['1']['meta_keywords']['value'], 0, 255),
             $converted['translations'][$this->languageUuid]['keywords']
         );
+    }
+
+    #[DataProvider('categoryImagePathProvider')]
+    public function testConvertCategoryImagePath(string $sourcePath, string $expectedUri): void
+    {
+        $categoryData = require __DIR__ . '/../../../_fixtures/category_data.php';
+        $categoryData[1]['image'] = $sourcePath;
+
+        $this->mediaFileService->resetMediaFileArray();
+        $this->categoryConverter20->convert(
+            $categoryData[1],
+            Context::createDefaultContext(),
+            $this->migrationContext20
+        );
+
+        $mediaFiles = $this->mediaFileService->getMediaFileArray();
+
+        static::assertCount(1, $mediaFiles);
+        static::assertSame($expectedUri, $mediaFiles[0]['uri']);
+    }
+
+    /**
+     * @return iterable<string, array{sourcePath: string, expectedUri: string}>
+     */
+    public static function categoryImagePathProvider(): iterable
+    {
+        yield 'bare category image filename' => [
+            'sourcePath' => 'example.jpg',
+            'expectedUri' => '/media/catalog/category/example.jpg',
+        ];
+
+        yield 'category image with existing media prefix' => [
+            'sourcePath' => '/media/catalog/category/example.jpg',
+            'expectedUri' => '/media/catalog/category/example.jpg',
+        ];
+
+        yield 'category image with existing media prefix without leading slash' => [
+            'sourcePath' => 'media/catalog/category/example.jpg',
+            'expectedUri' => '/media/catalog/category/example.jpg',
+        ];
     }
 
     public function testConvert21(): void


### PR DESCRIPTION
Closes: https://github.com/shopware/shopware/issues/18903

### 1. Why is this change necessary?
Magento category image values can already contain the `/media/catalog/category/` prefix. The Migration Assistant currently prepends this prefix unconditionally, resulting in invalid paths such as:

`/media/catalog/category//media/catalog/category/example.jpg`

As a result, category images cannot be downloaded during migration.

### 2. What does this change do, exactly?

Category media paths are normalized before creating the migration media-file URI.

The prefix is added only when it is missing, and leading slashes are normalized so that all supported input formats produce a canonical URI:

`/media/catalog/category/example.jpg`

A regression test covers bare filenames as well as paths with and without a leading slash.