### PR TITLE
fix: use 1.0 currency factor for same-currency Magento orders

### DIFF
--- a/src/Profile/Magento/Converter/OrderConverter.php
+++ b/src/Profile/Magento/Converter/OrderConverter.php
@@ -169,6 +169,9 @@ abstract class OrderConverter extends MagentoConverter
 
         $this->convertValue($converted, 'orderNumber', $data['orders'], 'increment_id');
         $this->convertValue($converted, 'currencyFactor', $data['orders'], 'store_to_order_rate', self::TYPE_FLOAT);
+        if (($converted['currencyFactor'] ?? 0.0) <= 0.0) {
+            $converted['currencyFactor'] = 1.0;
+        }
         $this->convertValue($converted, 'orderDateTime', $data['orders'], 'created_at', self::TYPE_DATETIME);
 
         $this->convertCurrency($converted, $data);

--- a/tests/Profile/Magento2/Converter/Magento2OrderConverterTest.php
+++ b/tests/Profile/Magento2/Converter/Magento2OrderConverterTest.php
@@ -277,6 +277,7 @@ class Magento2OrderConverterTest extends TestCase
         static::assertNotNull($converted);
         static::assertNull($convertResult->getUnmapped());
         static::assertArrayHasKey('id', $converted);
+        static::assertSame(1.0, $converted['currencyFactor']);
         static::assertNotNull($convertResult->getMappingUuid());
         static::assertSame($this->storeUuid, $converted['salesChannelId']);
         $price = $converted['price'];
@@ -287,6 +288,19 @@ class Magento2OrderConverterTest extends TestCase
         static::assertSame($this->shippingMethod, $converted['deliveries'][0]['shippingMethodId']);
         static::assertNotNull($converted['itemRounding']);
         static::assertNotNull($converted['totalRounding']);
+    }
+
+    public function testConvertWithZeroCurrencyFactor(): void
+    {
+        $context = Context::createDefaultContext();
+        $orderData = require __DIR__ . '/../../../_fixtures/order_data.php';
+        $orderData[0]['orders']['store_to_order_rate'] = '0.0000';
+
+        $convertResult = $this->orderConverter->convert($orderData[0], $context, $this->migrationContext);
+        $converted = $convertResult->getConverted();
+
+        static::assertNotNull($converted);
+        static::assertSame(1.0, $converted['currencyFactor']);
     }
 
     public function testConvertWithInvalidShippingMethod(): void


### PR DESCRIPTION
Closes: https://github.com/shopware/shopware/issues/18905
 
### 1. Why is this change necessary?

Magento stores `store_to_order_rate` as `0.0000` for orders placed in the shop's base currency. The migration currently copies this value directly to Shopware's `currencyFactor`, resulting in orders with a currency factor of `0`.

### 2. What does this change do, exactly?

Uses `1.0` as the fallback when `store_to_order_rate` is missing or less than or equal to zero. Valid currency conversion rates remain unchanged.

Adds regression coverage for zero and regular currency factors.

Wait for: https://github.com/shopware/SwagMigrationMagento/pull/65 to fix the PHPStan pipeline:
