### PR TITLE
test: probe the Codecov setup with uncovered source

### DIFF
--- a/src/CoverageProbe.php
+++ b/src/CoverageProbe.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\MigrationMagento;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal Probe for the Codecov setup — DO NOT MERGE.
+ */
+#[Package('fundamentals@after-sales')]
+class CoverageProbe
+{
+    public function classify(int $value): string
+    {
+        if ($value < 0) {
+            return 'negative';
+        }
+
+        if ($value === 0) {
+            return 'zero';
+        }
+
+        if ($value < 10) {
+            return 'small';
+        }
+
+        if ($value < 100) {
+            return 'medium';
+        }
+
+        return 'large';
+    }
+
+    /**
+     * @param list<int> $values
+     *
+     * @return list<string>
+     */
+    public function classifyAll(array $values): array
+    {
+        $result = [];
+        foreach ($values as $value) {
+            $result[] = $this->classify($value);
+        }
+
+        return $result;
+    }
+
+    public function describe(int $value): string
+    {
+        $label = $this->classify($value);
+
+        if ($label === 'zero') {
+            return 'the value is zero';
+        }
+
+        return \sprintf('the value is %s (%d)', $label, $value);
+    }
+}


### PR DESCRIPTION
**Probe for #68 — do not merge.** Based on that branch, not on `trunk`.

Adds `src/CoverageProbe.php`: ~20 uncovered lines with no test, so the upload carries a patch at 0% coverage.

What it can prove now:

- the `Upload coverage to Codecov` step runs on exactly one leg (`mysql:8.0` / PHP 8.3) and the upload is accepted — which is also the first real test of whether the organisation `CODECOV_TOKEN` is a global upload token rather than the platform repo's own;
- `codecov/project` and `codecov/patch` appear as commit statuses;
- the reported paths are `src/CoverageProbe.php` and not `custom/plugins/SwagMigrationMagento/src/CoverageProbe.php` — if they are nested, `.github/codecov.yml` needs a `fixes:` entry.

What it cannot prove yet: that a coverage **drop** turns the status red. Codecov has never received a report for this repository, so there is no `trunk` baseline to compare against and both statuses may come back neutral on a first upload. That part is only demonstrable once #68 has merged and one `push: trunk` run has established the baseline — at which point this branch can be re-run.

Part of [shopware/shopware#18667](https://github.com/shopware/shopware/issues/18667).
